### PR TITLE
Use new tracing API

### DIFF
--- a/lib/active_record/connection_adapters/honeycomb_adapter.rb
+++ b/lib/active_record/connection_adapters/honeycomb_adapter.rb
@@ -85,7 +85,7 @@ module ActiveRecord
 
       def exec_insert(sql, name, binds, *args)
         sending_honeycomb_event(sql, name, binds) do |event|
-          adding_span_metadata_if_available(event) do
+          with_tracing_if_available(event) do
             super
           end
         end

--- a/lib/active_record/connection_adapters/honeycomb_adapter.rb
+++ b/lib/active_record/connection_adapters/honeycomb_adapter.rb
@@ -51,6 +51,7 @@ module ActiveRecord
           end
 
           @builder = @client.builder.add(
+            'type' => 'db',
             'meta.package' => 'activerecord',
             'meta.package_version' => ActiveRecord::VERSION::STRING,
           )

--- a/lib/active_record/connection_adapters/honeycomb_adapter.rb
+++ b/lib/active_record/connection_adapters/honeycomb_adapter.rb
@@ -51,7 +51,6 @@ module ActiveRecord
           end
 
           @builder = @client.builder.add(
-            'type' => 'db',
             'meta.package' => 'activerecord',
             'meta.package_version' => ActiveRecord::VERSION::STRING,
           )
@@ -69,7 +68,7 @@ module ActiveRecord
 
       def execute(sql, name = nil, *args)
         sending_honeycomb_event(sql, name, []) do |event|
-          adding_span_metadata_if_available(event) do
+          with_tracing_if_available(event) do
             super
           end
         end
@@ -77,7 +76,7 @@ module ActiveRecord
 
       def exec_query(sql, name = 'SQL', binds = [], *args)
         sending_honeycomb_event(sql, name, binds) do |event|
-          adding_span_metadata_if_available(event) do
+          with_tracing_if_available(event) do
             super
           end
         end
@@ -93,7 +92,7 @@ module ActiveRecord
 
       def exec_delete(sql, name, binds = [], *args)
         sending_honeycomb_event(sql, name, binds) do |event|
-          adding_span_metadata_if_available(event) do
+          with_tracing_if_available(event) do
             super
           end
         end
@@ -101,7 +100,7 @@ module ActiveRecord
 
       def exec_update(sql, name, binds = [], *args)
         sending_honeycomb_event(sql, name, binds) do |event|
-          adding_span_metadata_if_available(event) do
+          with_tracing_if_available(event) do
             super
           end
         end
@@ -159,17 +158,14 @@ module ActiveRecord
         sql.sub(/\s+.*/, '').upcase
       end
 
-      def adding_span_metadata_if_available(event)
-        return yield unless event && defined?(::Honeycomb.trace_id)
+      def with_tracing_if_available(event)
+        return yield unless event && defined?(::Honeycomb::Beeline::VERSION)
 
-        trace_id = ::Honeycomb.trace_id
-
-        event.add_field 'trace.trace_id', trace_id if trace_id
-        span_id = SecureRandom.uuid
-        event.add_field 'trace.span_id', span_id
-
-        ::Honeycomb.with_span_id(span_id) do |parent_span_id|
-          event.add_field 'trace.parent_id', parent_span_id
+        ::Honeycomb.span_for_existing_event(
+          event,
+          name: nil, # leave blank since we set it above
+          type: 'db',
+        ) do
           yield
         end
       end

--- a/spec/connection_adapters/honeycomb_adapter_spec.rb
+++ b/spec/connection_adapters/honeycomb_adapter_spec.rb
@@ -1,4 +1,8 @@
 RSpec.shared_examples_for 'records a database query' do |name:, preceding_events: 0, sql_match:, table:, sql_not_match: nil, binds: {}|
+  it 'sends a db event' do
+    expect(last_event.data['type']).to eq('db')
+  end
+
   it 'sends just one event' do
     expect($fakehoney.events.size).to eq(preceding_events + 1),
       "expected exactly one event, got: #{$fakehoney.events.drop(preceding_events).map {|event| event.data['name'] }.join(', ')}"

--- a/spec/connection_adapters/honeycomb_adapter_spec.rb
+++ b/spec/connection_adapters/honeycomb_adapter_spec.rb
@@ -1,8 +1,4 @@
 RSpec.shared_examples_for 'records a database query' do |name:, preceding_events: 0, sql_match:, table:, sql_not_match: nil, binds: {}|
-  it 'sends a db event' do
-    expect(last_event.data['type']).to eq('db')
-  end
-
   it 'sends just one event' do
     expect($fakehoney.events.size).to eq(preceding_events + 1),
       "expected exactly one event, got: #{$fakehoney.events.drop(preceding_events).map {|event| event.data['name'] }.join(', ')}"


### PR DESCRIPTION
This refactors the tracing support to use the new unreleased tracing API in https://github.com/honeycombio/beeline-ruby/pull/4.

Note this is a "stacked" PR that depends on the changes in #2 - merge that PR before this one, and don't forget to change the "base branch" to master before merging.