### PR TITLE
Test on multiple ActiveRecord versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Gemfile.lock
+Gemfile*.lock
 spec/examples.txt
 .yardoc
 doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
 env:
   - DB_ADAPTER=postgresql
   - DB_ADAPTER=mysql2
+gemfile:
+  - Gemfile
+  - Gemfile.ar4.rb
 services:
   - mysql
   - postgresql

--- a/Gemfile.ar4.rb
+++ b/Gemfile.ar4.rb
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'pry-byebug', group: :development
+
+gem 'activerecord', '< 5'
+# required by ActiveRecord 4
+gem 'pg', '~> 0.15'

--- a/Gemfile.ar4.rb
+++ b/Gemfile.ar4.rb
@@ -7,3 +7,4 @@ gem 'pry-byebug', group: :development
 gem 'activerecord', '< 5'
 # required by ActiveRecord 4
 gem 'pg', '~> 0.15'
+gem 'mysql2', '< 0.5', '>= 0.3.13'

--- a/spec/support/db.rb
+++ b/spec/support/db.rb
@@ -28,7 +28,7 @@ module TestDB
     end
 
     def disconnect
-      @connection_pool.disconnect
+      @connection_pool.disconnect!
     end
   end
 end


### PR DESCRIPTION
This sets up the CI build to test on multiple ActiveRecord versions. Unfortunately, the CI build fails at the moment, because the code for capturing bound query params (added in #2) apparently works on ActiveRecord 5 but not on ActiveRecord 4.

It's also easy to extend this to test on ActiveRecord 3 as well, but all the tests fail - will probably take some investigation to get this working on ActiveRecord 3.