### PR TITLE
Add sqlite3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
 env:
   - DB_ADAPTER=postgresql
   - DB_ADAPTER=mysql2
+  - DB_ADAPTER=sqlite3
 services:
   - mysql
   - postgresql

--- a/lib/active_record/connection_adapters/honeycomb_adapter.rb
+++ b/lib/active_record/connection_adapters/honeycomb_adapter.rb
@@ -24,7 +24,7 @@ module ActiveRecord
       if real_connection.class.ancestors.include? ConnectionAdapters::HoneycombAdapter
         logger.debug "#{log_prefix} found #{real_connection.class} with #{ConnectionAdapters::HoneycombAdapter} already included"
       else
-        real_connection.class.include ConnectionAdapters::HoneycombAdapter
+        real_connection.class.prepend ConnectionAdapters::HoneycombAdapter
       end
 
       real_connection
@@ -38,7 +38,7 @@ module ActiveRecord
         attr_reader :builder
         attr_accessor :logger
 
-        def included(klazz)
+        def prepended(klazz)
           debug "included into #{klazz.name}"
 
           if @client

--- a/spec/db/config-sqlite3.yml
+++ b/spec/db/config-sqlite3.yml
@@ -1,0 +1,3 @@
+test:
+  adapter: sqlite3
+  database: spec/db/activerecord-honeycomb-test.sqlite3


### PR DESCRIPTION
The sqlite3 adapter defines the methods that we are trying to override
in the adapter class itself so we need to prepend the module so that
the methods exist in the correct place in the ancestor chain of the
adapter.