### PR TITLE
Add sql query source location to trace event field

### DIFF
--- a/lib/active_record/connection_adapters/honeycomb_adapter.rb
+++ b/lib/active_record/connection_adapters/honeycomb_adapter.rb
@@ -122,7 +122,7 @@ module ActiveRecord
           event = builder.event
 
           event.add_field 'db.sql', sql
-          event.add_field 'db.query_source', extract_query_source_location(caller)
+          event.add_field 'db.caller', extract_query_source_location(caller)
           event.add_field 'name', name || query_name(sql)
 
           binds.each do |bind|

--- a/spec/connection_adapters/honeycomb_adapter_spec.rb
+++ b/spec/connection_adapters/honeycomb_adapter_spec.rb
@@ -21,6 +21,12 @@ RSpec.shared_examples_for 'records a database query' do |name:, preceding_events
     expect(sql).to include(quote_table_name(table))
   end
 
+  it 'records the SQL query source' do
+    expect(last_event.data).to include('db.query_source')
+    source = last_event.data['db.query_source']
+    expect(source).to match(/\w+\.rb:\d+:in `\w+'/)
+  end
+
   # active record 4 and mysql doesn't support parameterised queries
   unless ENV["DB_ADAPTER"] == "mysql2" && ActiveRecord.version < Gem::Version.new("5")
     it 'records the parameterised SQL query rather than the literal parameter values' do

--- a/spec/connection_adapters/honeycomb_adapter_spec.rb
+++ b/spec/connection_adapters/honeycomb_adapter_spec.rb
@@ -22,8 +22,8 @@ RSpec.shared_examples_for 'records a database query' do |name:, preceding_events
   end
 
   it 'records the SQL query source' do
-    expect(last_event.data).to include('db.query_source')
-    source = last_event.data['db.query_source']
+    expect(last_event.data).to include('db.caller')
+    source = last_event.data['db.caller']
     expect(source).to match(/\w+\.rb:\d+:in `\w+'/)
   end
 


### PR DESCRIPTION
Rails 5.2 adds a "verbose query logs" option that will log the line in the app that triggered a query to be run. I've copied that functionality (using activesupport's backtrace_cleaner to find the relevant line, which is how Rails 6.0 accomplishes it) into the connection adapter so the Trace's query details can expose it.

*db.query_source*:

![screenshot_20190227_152901](https://user-images.githubusercontent.com/184/53527520-6ed4d400-3aa4-11e9-8254-5af037e2072f.png)
