### PR TITLE
Fix for Direct call to ActiveRecord exec_query causes undefined method error

### DIFF
--- a/lib/active_record/connection_adapters/honeycomb_adapter.rb
+++ b/lib/active_record/connection_adapters/honeycomb_adapter.rb
@@ -131,7 +131,11 @@ module ActiveRecord
               event.add_field "db.params.#{bind.name}", bind.value
             else # ActiveRecord 4
               column, value = bind
-              event.add_field "db.params.#{column&.name}", value
+              if column.respond_to?(:name)
+                event.add_field "db.params.#{column.name}", value
+              else
+                event.add_field "db.params.#{column}", value
+              end
             end
           end
 

--- a/lib/active_record/connection_adapters/honeycomb_adapter.rb
+++ b/lib/active_record/connection_adapters/honeycomb_adapter.rb
@@ -131,7 +131,7 @@ module ActiveRecord
               event.add_field "db.params.#{bind.name}", bind.value
             else # ActiveRecord 4
               column, value = bind
-              event.add_field "db.params.#{column.name}", value
+              event.add_field "db.params.#{column&.name}", value
             end
           end
 


### PR DESCRIPTION
This fixes an issue described in #14 

I could use some help writing tests for this, but we have been running this in production for a couple months now with no issues.